### PR TITLE
Use a shared example in acceptance testing

### DIFF
--- a/spec/acceptance/mosquitto_spec.rb
+++ b/spec/acceptance/mosquitto_spec.rb
@@ -2,16 +2,8 @@ require 'spec_helper_acceptance'
 
 describe 'mosquitto' do
   context 'with default parameters' do
-    let(:pp) do
-      <<-PUPPET
-      include mosquitto
-      PUPPET
-    end
-
-    it 'runs successfully' do
-      # Apply twice to ensure no errors the second time.
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) { 'include mosquitto' }
     end
 
     describe service('mosquitto') do


### PR DESCRIPTION
This was introduced in voxpupupuli-acceptance 1.0.