### PR TITLE
don't try to create config and systemd dropin for ensure absent

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,7 +11,7 @@ class mosquitto::config (
   assert_private()
 
   file { '/etc/mosquitto/mosquitto.conf':
-    ensure  => 'file',
+    ensure  => bool2str($mosquitto::package_ensure == 'absent', 'absent', 'file'),
     content => epp("${module_name}/mosquitto.conf", { 'config' => $config }),
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -28,6 +28,7 @@ class mosquitto::service (
       | EOT
 
     systemd::dropin_file { 'mosquitto-override.conf':
+      ensure         => bool2str($ensure == 'running', 'present', 'absent'),
       unit           => 'mosquitto.service',
       content        => $content,
       notify_service => true,

--- a/spec/classes/mosquitto_spec.rb
+++ b/spec/classes/mosquitto_spec.rb
@@ -16,8 +16,26 @@ describe 'mosquitto' do
         it { is_expected.to contain_class('mosquitto::install') }
         it { is_expected.to contain_class('mosquitto::config') }
         it { is_expected.to contain_service('mosquitto') }
+        it { is_expected.to contain_systemd__dropin_file('mosquitto-override.conf').with_ensure('present') }
         it { is_expected.to contain_package('mosquitto') }
         it { is_expected.to contain_file('/etc/mosquitto/mosquitto.conf') }
+      end
+
+      context 'with ensure => absent' do
+        let :params do
+          {
+            package_ensure: 'absent',
+            service_ensure: 'stopped',
+            service_enable: false
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('mosquitto') }
+        it { is_expected.to contain_service('mosquitto').with_ensure('stopped') }
+        it { is_expected.to contain_systemd__dropin_file('mosquitto-override.conf').with_ensure('absent') }
+        it { is_expected.to contain_package('mosquitto').with_ensure('absent') }
+        it { is_expected.to contain_file('/etc/mosquitto/mosquitto.conf').with_ensure('absent') }
       end
     end
   end


### PR DESCRIPTION
`/etc/mosquitto` doesn't exist, which leads to errors like:

    Could not set 'file' on ensure: No such file or directory
    A directory component in
    /etc/mosquitto/mosquitto.conf20220502-25915-2sgpu9.lock
    does not exist or is a dangling symbolic link

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
