### PR TITLE
Allow puppet/systemd 5.x and 6.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 3.1.0 < 5.0.0"
+      "version_requirement": ">= 3.1.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
5.x dropped Puppet 6 support, which we don't support anyway 6.x dropped Ubuntu 18.04 support, which we should drop soon

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
