### PR TITLE
Move to setup_acceptance_node.pp

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,4 +1,6 @@
 ---
+spec/spec_helper_acceptance.rb:
+  unmanaged: false
 .puppet-lint.rc:
   enabled_lint_checks:
     - parameter_documentation

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,0 +1,15 @@
+case $facts['os']['name'] {
+  'CentOS': {
+    # Mosquitto is packaged in EPEL
+    package { 'epel-release':
+      ensure => installed,
+    }
+  }
+  'Fedora': {
+    # For serverspec
+    package { 'iproute':
+      ensure => installed,
+    }
+  }
+  default: {}
+}

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
-# This file is completely managed via modulesync
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
-configure_beaker do |host|
-  case fact_on(host, 'operatingsystem')
-  when 'CentOS'
-    host.install_package('epel-release')
-  when 'Fedora'
-    host.install_package('iproute')
-  end
-end
+configure_beaker(modules: :metadata)
+
+Dir['./spec/support/acceptance/**/*.rb'].sort.each { |f| require f }


### PR DESCRIPTION
Rather than writing the setup code in Ruby, this is now written in Puppet. That works better with modulesync. It also switches from the legacy operatingsystem fact to the modern os.name fact. This is now easily detectable with puppet-lint.