### PR TITLE
explicitly call mosquitto.conf.epp file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -23,6 +23,6 @@ class mosquitto::config (
 
   file { "${etc_prefix}/mosquitto/mosquitto.conf":
     ensure  => bool2str($mosquitto::package_ensure == 'absent', 'absent', 'file'),
-    content => epp("${module_name}/mosquitto.conf", { 'config' => $config + $default_config }),
+    content => epp("${module_name}/mosquitto.conf.epp", { 'config' => $config + $default_config }),
   }
 }


### PR DESCRIPTION
don't rely on magic that appends the .epp

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
